### PR TITLE
Fixing scrobbling & better error parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.novoda:bintray-release:0.3.4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/lastfm-library/build.gradle
+++ b/lastfm-library/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.novoda.bintray-release'
 
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -24,7 +24,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 
 }
 publish {

--- a/lastfm-library/src/main/java/com/ag/lfm/ScrobbleParameters.java
+++ b/lastfm-library/src/main/java/com/ag/lfm/ScrobbleParameters.java
@@ -17,6 +17,8 @@ package com.ag.lfm;
 
 import com.ag.lfm.util.LfmUtil;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -84,7 +86,17 @@ public class ScrobbleParameters extends LinkedList<LfmParameters> implements Com
                 .append("method=track.scrobble");
         for (int i = 0; i < this.size(); i++) {
             for (String p : this.get(i).keySet()) {
-                builder.append("&").append(p).append("[").append(i).append("]").append("=").append(this.get(i).get(p));
+                try {
+                    builder.append("&")
+                            .append(p)
+                            .append("[")
+                            .append(i)
+                            .append("]")
+                            .append("=")
+                            .append(URLEncoder.encode(this.get(i).get(p), "UTF-8"));
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                }
             }
         }
         builder.append("&").append("api_key").append("=").append(Lfm.getApiKey()).append("&").append("sk=")

--- a/lastfm-library/src/main/java/com/ag/lfm/api/httpClient/JSONOperation.java
+++ b/lastfm-library/src/main/java/com/ag/lfm/api/httpClient/JSONOperation.java
@@ -35,6 +35,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Scanner;
 
 /**
  * Sending request using AsyncTask.
@@ -192,9 +193,22 @@ public class JSONOperation extends AsyncTask<LfmRequest.LfmRequestListener, Void
                 error = null;
             }
         } else {
-            error.errorCode = connection.getResponseCode();
-            error.errorMessage = connection.getResponseMessage();
-            response = null;
+            reader = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
+            buffer = new StringBuffer();
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                buffer.append(line);
+            }
+
+            if (!buffer.toString().isEmpty()) {
+                JSONObject errorObject = new JSONObject(buffer.toString());
+                error = new LfmError(errorObject);
+            } else {
+                error.errorCode = connection.getResponseCode();
+                error.errorMessage = connection.getResponseMessage();
+                response = null;
+            }
         }
     }
 
@@ -230,9 +244,22 @@ public class JSONOperation extends AsyncTask<LfmRequest.LfmRequestListener, Void
             }
 
         } else {
-            error.errorCode = connection.getResponseCode();
-            error.errorMessage = connection.getResponseMessage();
-            response = null;
+            reader = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
+            buffer = new StringBuffer();
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                buffer.append(line);
+            }
+
+            if (!buffer.toString().isEmpty()) {
+                JSONObject errorObject = new JSONObject(buffer.toString());
+                error = new LfmError(errorObject);
+            } else {
+                error.errorCode = connection.getResponseCode();
+                error.errorMessage = connection.getResponseMessage();
+                response = null;
+            }
         }
 
     }
@@ -265,9 +292,22 @@ public class JSONOperation extends AsyncTask<LfmRequest.LfmRequestListener, Void
                 error = null;
             }
         } else {
-            error.errorCode = connection.getResponseCode();
-            error.errorMessage = connection.getResponseMessage();
-            response = null;
+            reader = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
+            buffer = new StringBuffer();
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                buffer.append(line);
+            }
+
+            if (!buffer.toString().isEmpty()) {
+                JSONObject errorObject = new JSONObject(buffer.toString());
+                error = new LfmError(errorObject);
+            } else {
+                error.errorCode = connection.getResponseCode();
+                error.errorMessage = connection.getResponseMessage();
+                response = null;
+            }
         }
     }
 }

--- a/lastfm-library/src/main/java/com/ag/lfm/api/httpClient/JSONOperation.java
+++ b/lastfm-library/src/main/java/com/ag/lfm/api/httpClient/JSONOperation.java
@@ -168,6 +168,25 @@ public class JSONOperation extends AsyncTask<LfmRequest.LfmRequestListener, Void
         response = null;
     }
 
+    private void parseBadRequestResponse() throws JSONException, IOException {
+        reader = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
+        StringBuffer buffer = new StringBuffer();
+
+        String line;
+        while ((line = reader.readLine()) != null) {
+            buffer.append(line);
+        }
+
+        if (!buffer.toString().isEmpty()) {
+            JSONObject errorObject = new JSONObject(buffer.toString());
+            error = new LfmError(errorObject);
+        } else {
+            error.errorCode = connection.getResponseCode();
+            error.errorMessage = connection.getResponseMessage();
+            response = null;
+        }
+    }
+
     /**
      * Method for JSON request.
      */
@@ -193,22 +212,7 @@ public class JSONOperation extends AsyncTask<LfmRequest.LfmRequestListener, Void
                 error = null;
             }
         } else {
-            reader = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
-            buffer = new StringBuffer();
-
-            String line;
-            while ((line = reader.readLine()) != null) {
-                buffer.append(line);
-            }
-
-            if (!buffer.toString().isEmpty()) {
-                JSONObject errorObject = new JSONObject(buffer.toString());
-                error = new LfmError(errorObject);
-            } else {
-                error.errorCode = connection.getResponseCode();
-                error.errorMessage = connection.getResponseMessage();
-                response = null;
-            }
+            parseBadRequestResponse();
         }
     }
 
@@ -244,22 +248,7 @@ public class JSONOperation extends AsyncTask<LfmRequest.LfmRequestListener, Void
             }
 
         } else {
-            reader = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
-            buffer = new StringBuffer();
-
-            String line;
-            while ((line = reader.readLine()) != null) {
-                buffer.append(line);
-            }
-
-            if (!buffer.toString().isEmpty()) {
-                JSONObject errorObject = new JSONObject(buffer.toString());
-                error = new LfmError(errorObject);
-            } else {
-                error.errorCode = connection.getResponseCode();
-                error.errorMessage = connection.getResponseMessage();
-                response = null;
-            }
+            parseBadRequestResponse();
         }
 
     }
@@ -292,22 +281,7 @@ public class JSONOperation extends AsyncTask<LfmRequest.LfmRequestListener, Void
                 error = null;
             }
         } else {
-            reader = new BufferedReader(new InputStreamReader(connection.getErrorStream()));
-            buffer = new StringBuffer();
-
-            String line;
-            while ((line = reader.readLine()) != null) {
-                buffer.append(line);
-            }
-
-            if (!buffer.toString().isEmpty()) {
-                JSONObject errorObject = new JSONObject(buffer.toString());
-                error = new LfmError(errorObject);
-            } else {
-                error.errorCode = connection.getResponseCode();
-                error.errorMessage = connection.getResponseMessage();
-                response = null;
-            }
+            parseBadRequestResponse();
         }
     }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.0"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "com.ag.testapplication"
         minSdkVersion 11
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -24,6 +24,6 @@ dependencies {
     testCompile 'junit:junit:4.12'
     compile project(':lastfm-library')
     compile 'com.squareup.picasso:picasso:2.5.2'
-    compile 'com.android.support:recyclerview-v7:24.0.0'
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:recyclerview-v7:25.3.1'
+    compile 'com.android.support:appcompat-v7:25.3.1'
 }


### PR DESCRIPTION
# Scrobbling Issue
Scrobbling tracks/artists with characters such as '+' in them wasn't working because the parameters need to be URLencoded when being sent.

# Better Error Parsing
Not all details from error messages were being parsed, as you were only looking for error messages when the status code was 200. This should now be resolved by looking for error messages in bad request responses.